### PR TITLE
Restore link to favicon.ico (bnc#917570)

### DIFF
--- a/dashboards/suse_theme/templates/_stylesheets.html
+++ b/dashboards/suse_theme/templates/_stylesheets.html
@@ -5,3 +5,4 @@
 <link href='{{ STATIC_URL }}dashboard/scss/suse.scss' type='text/scss' media='screen' rel='stylesheet' />
 {% endcompress %}
 
+<link rel="shortcut icon" href="{{ STATIC_URL }}dashboard/img/favicon.ico"/>


### PR DESCRIPTION
(cherry picked from commit dd0ff51ba2a90571134543d1a4d25d23327c261b)
