### PR TITLE
Use "Log In" instead of "Sign In" on login page

### DIFF
--- a/dashboards/suse_theme/templates/auth/_login.html
+++ b/dashboards/suse_theme/templates/auth/_login.html
@@ -29,5 +29,5 @@
 {% endblock %}
 
 {% block modal-footer %}
-  <button type="submit" class="btn btn-primary pull-right">{% trans "Sign In" %}</button>
+  <button type="submit" class="btn btn-primary pull-right">{% trans "Log In" %}</button>
 {% endblock %}


### PR DESCRIPTION
This has the benefit of enabling the use of upstream translations for
this string.
