### PR TITLE
Fix patterns for Django > 1.10

### DIFF
--- a/dashboards/help/guides/urls.py
+++ b/dashboards/help/guides/urls.py
@@ -12,11 +12,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from .views import GuidesView
 
 
-urlpatterns = patterns('',
-    url(r'^$', login_required(GuidesView.as_view()), name='index'))
+urlpatterns = [
+    url(r'^$', login_required(GuidesView.as_view()), name='index'),
+]


### PR DESCRIPTION
Pike requires Django 1.11 so fix the template pattern import which was
not compatible with that version. This fixes:

File
"/srv/www/openstack-dashboard/openstack_dashboard/dashboards/help/guides/\
    urls.py", line 15, in <module>
from django.conf.urls import patterns, url
ImportError: cannot import name patterns