### PR TITLE
Remove links to end user & admin user guides

### DIFF
--- a/dashboards/help/guides/templates/guides/index.html
+++ b/dashboards/help/guides/templates/guides/index.html
@@ -9,14 +9,6 @@
 {% block main %}
 <ul style="list-style-type:disc; margin-left:20px">
     <li>
-        <a href="{% static "help/user/" %}">End User Guide</a>
-        (<a href="{% static "help/suse-openstack-cloud-user_en.pdf" %}">PDF</a>)
-    </li>
-    <li>
-        <a href="{% static "help/admin/" %}">Admin User Guide</a>
-        (<a href="{% static "help/suse-openstack-cloud-admin_en.pdf" %}">PDF</a>)
-    </li>
-    <li>
         <a href="{% static "help/supplement/" %}">Supplement to Admin User Guide and End User Guide</a>
         (<a href="{% static "help/suse-openstack-cloud-supplement_en.pdf" %}">PDF</a>)
     </li>


### PR DESCRIPTION
We dropped these in Cloud 9.